### PR TITLE
fix frameCount to be framePerBurst in echo sample(audio_main.cpp)

### DIFF
--- a/aaudio/echo/src/main/cpp/audio_main.cpp
+++ b/aaudio/echo/src/main/cpp/audio_main.cpp
@@ -101,7 +101,7 @@ void AudioThreadProc(void* ctx) {
       assert(frameCount == framesPerBurst);
     } else {
       memset(buf, 0, sizeof(int16_t) * framesPerBurst * samplesPerFrame);
-      frameCount = samplesPerFrame;
+      frameCount = framesPerBurst;
     }
     frameCount = AAudioStream_write(eng->playStream_,
                                 buf,


### PR DESCRIPTION
should write silent audio of framesPerBurst rather than samplesPerFrame