### PR TITLE
Minor Bugfix

### DIFF
--- a/aaudio/echo/src/main/cpp/audio_main.cpp
+++ b/aaudio/echo/src/main/cpp/audio_main.cpp
@@ -167,7 +167,7 @@ Java_com_google_sample_aaudio_echo_MainActivity_createEngine(
   assert(engine.recordingStream_);
   PrintAudioStreamInfo(engine.recordingStream_);
 
-  aaudio_stream_state_t result = AAudioStream_requestStart(engine.playStream_);
+  aaudio_result_t result = AAudioStream_requestStart(engine.playStream_);
   if (result != AAUDIO_OK) {
     assert(result == AAUDIO_OK);
     return JNI_FALSE;

--- a/aaudio/hello-aaudio/src/main/cpp/audio_main.cpp
+++ b/aaudio/hello-aaudio/src/main/cpp/audio_main.cpp
@@ -150,7 +150,7 @@ Java_com_google_sample_aaudio_play_MainActivity_createEngine(
 
     PrintAudioStreamInfo(engine.playStream_);
 
-    aaudio_stream_state_t result = AAudioStream_requestStart(engine.playStream_);
+    aaudio_result_t result = AAudioStream_requestStart(engine.playStream_);
     if (result != AAUDIO_OK) {
       assert(result == AAUDIO_OK);
       return JNI_FALSE;


### PR DESCRIPTION
When using AAudioStream_requestStart() its return type should be aaudio_result_t.

Tested:  
    Mac build, run on Pixel
@dturner @philburk please kindly take a look, thanks!

