### PR TITLE
Using NDK-r15-beta1, retire aaudio wrapper

### DIFF
--- a/aaudio/README.md
+++ b/aaudio/README.md
@@ -10,7 +10,9 @@ Pre-requisites
 -----------
 * Android Device with recording capability, running Android API 25( Android O )
 * An external headphone (with a microphone) plugged into Android Device
+* NDK-r15 [Beta1](https://developer.android.com/ndk/downloads/index.html) and above
 * [Android Studio 2.3.0+](https://developer.android.com/studio/index.html)
+* [AAudio Guide](https://developer.android.com/ndk/guides/audio/aaudio/aaudio.html)
 
 Getting Started
 ---------------
@@ -18,7 +20,7 @@ Getting Started
 1. Launch Android Studio
 1. Import project: File --> New --> Import Project; browse to aaudio/build.gradle; and "OK"
 1. Open *File/Project Structure...*
-  - Click *Download* or *Select NDK location*.
+  - Click *Download* or *Select NDK location*: make sure to use ndk-r15-beta1+
 1. Click *Tools/Android/Sync Project with Gradle Files*.
 1. Click *Run/Run 'app'*.
 

--- a/aaudio/echo/build.gradle
+++ b/aaudio/echo/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId 'com.google.sample.com.google.sample.aaudio.echo'
-        minSdkVersion 24
+        minSdkVersion 25
         targetSdkVersion 25
         versionCode 1
         versionName '1.0'
@@ -15,10 +15,8 @@ android {
         }
         externalNativeBuild {
             cmake {
-                // With android studio 2.2.0 +cmake, app needs to pack shared lib to
-                // into APK. Refer to CMakeLists.txt for details
                 arguments '-DANDROID_STL=c++_shared', '-DANDROID_TOOLCHAIN=clang',
-                          '-DANDROID_PLATFORM=android-24'
+                          '-DANDROID_PLATFORM=android-26'
             }
         }
     }

--- a/aaudio/echo/src/main/cpp/CMakeLists.txt
+++ b/aaudio/echo/src/main/cpp/CMakeLists.txt
@@ -21,25 +21,15 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror")
 add_library(echo SHARED
             audio_main.cpp
             ${AAUDIO_COMMON_PATH}/utils/audio_common.cpp
-            ${AAUDIO_COMMON_PATH}/utils/debug_utils.cpp
-            ${AAUDIO_COMMON_PATH}/wrapper/src/aaudio_wrapper.c)
+            ${AAUDIO_COMMON_PATH}/utils/debug_utils.cpp)
 
 target_include_directories(echo PRIVATE
-                           ${AAUDIO_COMMON_PATH}/wrapper
                            ${AAUDIO_COMMON_PATH}/utils
                            ${AAUDIO_COMMON_PATH}/../android)
 
 # include libraries needed for echo lib
 target_link_libraries(echo
+                      aaudio
                       android
                       atomic
                       log)
-
-# Android Studio 2.2.0 with CMake support does not pack stl shared libraries,
-# so app needs to pack the right shared lib into APK. This sample uses solution
-# from https://github.com/jomof/ndk-stl to find the right stl shared lib to use
-# and copy it to the right place for Android Studio to pack. Android Studio 2.3.0+
-# does not need it!
-# Usage: download ndk-stl-config.cmake into app's directory hosting CMakeLists.txt
-#        and just use it with the following line
-#include(ndk-stl-config.cmake)

--- a/aaudio/echo/src/main/cpp/audio_main.cpp
+++ b/aaudio/echo/src/main/cpp/audio_main.cpp
@@ -133,12 +133,6 @@ Java_com_google_sample_aaudio_echo_MainActivity_createEngine(
 
   memset(&engine, 0, sizeof(engine));
 
-  // Initialize AAudio wrapper
-  if(!InitAAudio()) {
-    LOGE("AAudio is not supported on your platform, cannot proceed");
-    return JNI_FALSE;
-  }
-
   engine.sampleChannels_   = AUDIO_SAMPLE_CHANNELS;
   engine.sampleFormat_ = AAUDIO_FORMAT_PCM_I16;
   engine.bitsPerSample_  = SampleFormatToBpp(engine.sampleFormat_);

--- a/aaudio/hello-aaudio/build.gradle
+++ b/aaudio/hello-aaudio/build.gradle
@@ -15,11 +15,8 @@ android {
         }
         externalNativeBuild {
             cmake {
-                // With android studio 2.2.0 +cmake, app needs to pack shared lib to
-                // into APK. Refer to CMakeLists.txt for details
                 arguments '-DANDROID_STL=c++_shared', '-DANDROID_TOOLCHAIN=clang',
-                          // when new NDK out, this should be android-26
-                          '-DANDROID_PLATFORM=android-24'
+                          '-DANDROID_PLATFORM=android-26'
             }
         }
     }

--- a/aaudio/hello-aaudio/src/main/cpp/CMakeLists.txt
+++ b/aaudio/hello-aaudio/src/main/cpp/CMakeLists.txt
@@ -23,24 +23,15 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror")
 add_library(hello-aaudio SHARED
             audio_main.cpp
             ${AAUDIO_COMMON_PATH}/utils/audio_common.cpp
-            ${AAUDIO_COMMON_PATH}/utils/debug_utils.cpp
-            ${AAUDIO_COMMON_PATH}/wrapper/src/aaudio_wrapper.c)
+            ${AAUDIO_COMMON_PATH}/utils/debug_utils.cpp)
 
 target_include_directories(hello-aaudio PRIVATE
-                           ${AAUDIO_COMMON_PATH}/wrapper
                            ${AAUDIO_COMMON_PATH}/utils
                            ${AAUDIO_COMMON_PATH}/../android)
 
 # include libraries needed for hello-aaudio
 target_link_libraries(hello-aaudio
+                      aaudio
                       android
                       atomic
                       log)
-
-# Android Studio 2.2.0 with CMake support does not pack stl shared libraries,
-# so app needs to pack the right shared lib into APK. This sample uses solution
-# from https://github.com/jomof/ndk-stl to find the right stl shared lib to use
-# and copy it to the right place for Android Studio to pack
-# Usage: download ndk-stl-config.cmake into app's directory hosting CMakeLists.txt
-#        and just use it with the following line
-#include(ndk-stl-config.cmake)

--- a/aaudio/hello-aaudio/src/main/cpp/audio_main.cpp
+++ b/aaudio/hello-aaudio/src/main/cpp/audio_main.cpp
@@ -126,12 +126,6 @@ Java_com_google_sample_aaudio_play_MainActivity_createEngine(
 
     memset(&engine, 0, sizeof(engine));
 
-    // Initialize AAudio wrapper
-    if(!InitAAudio()) {
-      LOGE("AAudio is not supported on your platform, cannot proceed");
-      return JNI_FALSE;
-    }
-
     engine.sampleChannels_   = AUDIO_SAMPLE_CHANNELS;
     engine.sampleFormat_ = AAUDIO_FORMAT_PCM_I16;
     engine.bitsPerSample_ = SampleFormatToBpp(engine.sampleFormat_);

--- a/aaudio/third_party/aaudio/utils/audio_common.h
+++ b/aaudio/third_party/aaudio/utils/audio_common.h
@@ -19,7 +19,7 @@
 #define AAUDIO_AUDIO_COMMON_H
 
 #include <chrono>
-#include <include/AAudio_Wrapper.h>
+#include <aaudio/AAudio.h>
 
 #include "android_debug.h"
 #include "debug_utils.h"

--- a/aaudio/third_party/aaudio/utils/stream_builder.h
+++ b/aaudio/third_party/aaudio/utils/stream_builder.h
@@ -19,7 +19,7 @@
 #include <cassert>
 
 // Replace this include with NDK's AAudio.h when available
-#include <include/AAudio_Wrapper.h>
+#include <aaudio/AAudio.h>
 #define INVALID_AUDIO_PARAM 0
 
 class StreamBuilder {


### PR DESCRIPTION
@dturner @philburk @bbilodeau @qchong, may you please take a look and approve if it is ok?  thanks
Changes:
  1) use NDK-r15-beta1 ( the first version of NDK having aaudio)
  2) minor clean-up in gradle/cmakelists file for comment
