### PR TITLE
Force to android-O target for AAudio sample

### DIFF
--- a/aaudio/README.md
+++ b/aaudio/README.md
@@ -7,8 +7,9 @@ These samples demonstrate how to use AAudio API:
 [AAudio](https://android-dot-devsite.googleplex.com/ndk/guides/audio/aaudio/aaudio.html) is still in its early stage of development, this [android-ndk thread](https://groups.google.com/forum/#!topic/android-ndk/Ox7L8V5ZF5s) addresses some of the possible questions surrounding the new API.
 
 Pre-requisites
------------
-* Android Device with recording capability, running Android O DP2 or above (Developer's Preivew) API
+-------------
+* Android Device with recording capability
+* Android O DP2 or above (Developer's Preivew) API
 * An external headphone (with a microphone) plugged into Android Device
 * NDK-r15 [Beta2](https://developer.android.com/ndk/downloads/index.html) and above
 * [Android Studio 2.3.0+](https://developer.android.com/studio/index.html)

--- a/aaudio/echo/build.gradle
+++ b/aaudio/echo/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 'android-O'
     buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId 'com.google.sample.com.google.sample.aaudio.echo'
-        minSdkVersion 25
-        targetSdkVersion 25
+        minSdkVersion 'android-O'
+        targetSdkVersion 'android-O'
         versionCode 1
         versionName '1.0'
         ndk {

--- a/aaudio/hello-aaudio/build.gradle
+++ b/aaudio/hello-aaudio/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 'android-O'
     buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId 'com.google.sample.com.google.sample.aaudio.play'
-        minSdkVersion 25
-        targetSdkVersion 25
+        minSdkVersion 'android-O'
+        targetSdkVersion 'android-O'
         versionCode 1
         versionName '1.0'
         ndk {


### PR DESCRIPTION
this should fix this one:
  https://github.com/googlesamples/android-audio-high-performance/issues/47

@bbilodeau, @dturner @GunNan please take a quick look?  thanks