### PR TITLE
Fix issue where stream builder settings are not reset

### DIFF
--- a/aaudio/third_party/aaudio/utils/stream_builder.h
+++ b/aaudio/third_party/aaudio/utils/stream_builder.h
@@ -24,17 +24,8 @@
 
 class StreamBuilder {
 public:
-    explicit StreamBuilder() {
-      aaudio_result_t  result = AAudio_createStreamBuilder(&builder_);
-      if (result != AAUDIO_OK && !builder_) {
-          assert(false);
-      }
-    }
-    ~StreamBuilder() {
-      if (builder_)
-        AAudioStreamBuilder_delete(builder_);
-      builder_ = nullptr;
-    };
+    explicit StreamBuilder() {}
+    ~StreamBuilder() {};
 
     /*
      * purposely left
@@ -53,6 +44,12 @@ public:
             AAudioStream_dataCallback  callback = nullptr,
             void    *userData = nullptr) {
 
+      AAudioStreamBuilder* builder_;
+      aaudio_result_t  result = AAudio_createStreamBuilder(&builder_);
+      if (result != AAUDIO_OK && !builder_) {
+        assert(false);
+      }
+
       AAudioStreamBuilder_setFormat(builder_, format);
       AAudioStreamBuilder_setSharingMode(builder_, sharing);
       AAudioStreamBuilder_setPerformanceMode(builder_, performanceMode);
@@ -65,16 +62,16 @@ public:
       AAudioStreamBuilder_setDataCallback(builder_, callback, userData);
 
       AAudioStream* stream;
-      aaudio_result_t result = AAudioStreamBuilder_openStream(builder_, &stream);
+      result = AAudioStreamBuilder_openStream(builder_, &stream);
       if (result != AAUDIO_OK) {
         assert(false);
         stream = nullptr;
       }
+
+      AAudioStreamBuilder_delete(builder_);
+
       return stream;
     }
-
-private:
-    AAudioStreamBuilder* builder_;
 };
 
 #endif //AAUDIO_STREAM_BIULDER_H

--- a/aaudio/third_party/aaudio/utils/stream_builder.h
+++ b/aaudio/third_party/aaudio/utils/stream_builder.h
@@ -44,31 +44,31 @@ public:
             AAudioStream_dataCallback  callback = nullptr,
             void    *userData = nullptr) {
 
-      AAudioStreamBuilder* builder_;
-      aaudio_result_t  result = AAudio_createStreamBuilder(&builder_);
-      if (result != AAUDIO_OK && !builder_) {
+      AAudioStreamBuilder* builder;
+      aaudio_result_t  result = AAudio_createStreamBuilder(&builder);
+      if (result != AAUDIO_OK && !builder) {
         assert(false);
       }
 
-      AAudioStreamBuilder_setFormat(builder_, format);
-      AAudioStreamBuilder_setSharingMode(builder_, sharing);
-      AAudioStreamBuilder_setPerformanceMode(builder_, performanceMode);
-      AAudioStreamBuilder_setDirection(builder_, dir);
-      AAudioStreamBuilder_setSampleRate(builder_, sampleRate);
-      AAudioStreamBuilder_setSamplesPerFrame(builder_, samplesPerFrame);
+      AAudioStreamBuilder_setFormat(builder, format);
+      AAudioStreamBuilder_setSharingMode(builder, sharing);
+      AAudioStreamBuilder_setPerformanceMode(builder, performanceMode);
+      AAudioStreamBuilder_setDirection(builder, dir);
+      AAudioStreamBuilder_setSampleRate(builder, sampleRate);
+      AAudioStreamBuilder_setSamplesPerFrame(builder, samplesPerFrame);
       if (sampleRate != INVALID_AUDIO_PARAM) {
-        AAudioStreamBuilder_setSampleRate(builder_, sampleRate);
+        AAudioStreamBuilder_setSampleRate(builder, sampleRate);
       }
-      AAudioStreamBuilder_setDataCallback(builder_, callback, userData);
+      AAudioStreamBuilder_setDataCallback(builder, callback, userData);
 
       AAudioStream* stream;
-      result = AAudioStreamBuilder_openStream(builder_, &stream);
+      result = AAudioStreamBuilder_openStream(builder, &stream);
       if (result != AAUDIO_OK) {
         assert(false);
         stream = nullptr;
       }
 
-      AAudioStreamBuilder_delete(builder_);
+      AAudioStreamBuilder_delete(builder);
 
       return stream;
     }


### PR DESCRIPTION
The StreamBuilder caches its instance of AAudioStreamBuilder which means that successive calls to StreamBuilder.CreateStream inherit the previous call's settings. This can have unintended side effects, including setting the same dataCallback function on a different stream.
