### PR TITLE
Deprecate following functions:

### DIFF
--- a/aaudio/echo/src/main/cpp/echo_audio_engine.cc
+++ b/aaudio/echo/src/main/cpp/echo_audio_engine.cc
@@ -251,7 +251,7 @@ void EchoAudioEngine::setupPlaybackStreamParameters(AAudioStreamBuilder *builder
  */
 void EchoAudioEngine::setupCommonStreamParameters(AAudioStreamBuilder *builder) {
   AAudioStreamBuilder_setFormat(builder, sampleFormat_);
-  AAudioStreamBuilder_setSamplesPerFrame(builder, sampleChannels_);
+  AAudioStreamBuilder_setChannelCount(builder, sampleChannels_);
 
   // We request EXCLUSIVE mode since this will give us the lowest possible latency.
   // If EXCLUSIVE mode isn't available the builder will fall back to SHARED mode.

--- a/aaudio/hello-aaudio/src/main/cpp/play_audio_engine.cc
+++ b/aaudio/hello-aaudio/src/main/cpp/play_audio_engine.cc
@@ -179,7 +179,7 @@ void PlayAudioEngine::prepareOscillators() {
 void PlayAudioEngine::setupPlaybackStreamParameters(AAudioStreamBuilder *builder) {
   AAudioStreamBuilder_setDeviceId(builder, playbackDeviceId_);
   AAudioStreamBuilder_setFormat(builder, sampleFormat_);
-  AAudioStreamBuilder_setSamplesPerFrame(builder, sampleChannels_);
+  AAudioStreamBuilder_setChannelCount(builder, sampleChannels_);
 
   // We request EXCLUSIVE mode since this will give us the lowest possible latency.
   // If EXCLUSIVE mode isn't available the builder will fall back to SHARED mode.

--- a/aaudio/third_party/aaudio/utils/audio_common.cc
+++ b/aaudio/third_party/aaudio/utils/audio_common.cc
@@ -62,7 +62,7 @@ void PrintAudioStreamInfo(const AAudioStream * stream) {
     LOGI("FramesPerBurst: %d", STREAM_CALL(getFramesPerBurst));
     LOGI("XRunCount: %d", STREAM_CALL(getXRunCount));
     LOGI("SampleRate: %d", STREAM_CALL(getSampleRate));
-    LOGI("SamplesPerFrame: %d", STREAM_CALL(getSamplesPerFrame));
+    LOGI("SamplesPerFrame: %d", STREAM_CALL(getChannelCount));
     LOGI("DeviceId: %d", STREAM_CALL(getDeviceId));
     LOGI("Format: %s",  FormatToString(STREAM_CALL(getFormat)));
     LOGI("SharingMode: %s", (STREAM_CALL(getSharingMode)) == AAUDIO_SHARING_MODE_EXCLUSIVE ?

--- a/aaudio/third_party/aaudio/wrapper/include/AAudio_Wrapper.h
+++ b/aaudio/third_party/aaudio/wrapper/include/AAudio_Wrapper.h
@@ -208,8 +208,8 @@ extern AAUDIO_API void (*AAudioStreamBuilder_setSampleRate)(AAudioStreamBuilder*
  * @param builder reference provided by AAudio_createStreamBuilder()
  * @param samplesPerFrame Number of samples in one frame, ie. numChannels.
  */
-extern AAUDIO_API void (*AAudioStreamBuilder_setSamplesPerFrame)(AAudioStreamBuilder* builder,
-                                                   int32_t samplesPerFrame);
+extern AAUDIO_API void (*AAudioStreamBuilder_setChannelCount)(AAudioStreamBuilder* builder,
+                                                   int32_t channelCount);
 
 /**
  * Request a sample data format, for example AAUDIO_FORMAT_PCM_I16.
@@ -672,7 +672,7 @@ extern AAUDIO_API int32_t (*AAudioStream_getSampleRate)(AAudioStream* stream);
  * @param stream reference provided by AAudioStreamBuilder_openStream()
  * @return actual samples per frame
  */
-extern AAUDIO_API int32_t (*AAudioStream_getSamplesPerFrame)(AAudioStream* stream);
+extern AAUDIO_API int32_t (*AAudioStream_getChannelCount)(AAudioStream* stream);
 
 /**
  * @param stream reference provided by AAudioStreamBuilder_openStream()

--- a/aaudio/third_party/aaudio/wrapper/src/aaudio_wrapper.c
+++ b/aaudio/third_party/aaudio/wrapper/src/aaudio_wrapper.c
@@ -32,8 +32,8 @@ void (*AAudioStreamBuilder_setDeviceId )(AAudioStreamBuilder* builder,
 
 void (*AAudioStreamBuilder_setSampleRate )(AAudioStreamBuilder* builder,
                                        int32_t sampleRate);
-void (*AAudioStreamBuilder_setSamplesPerFrame )(AAudioStreamBuilder* builder,
-                                            int32_t samplesPerFrame);
+void (*AAudioStreamBuilder_setChannelCount )(AAudioStreamBuilder* builder,
+                                            int32_t channelCount);
 void (*AAudioStreamBuilder_setFormat )(AAudioStreamBuilder* builder,
                                    aaudio_format_t format);
 void (*AAudioStreamBuilder_setSharingMode )(AAudioStreamBuilder* builder,
@@ -97,7 +97,7 @@ int32_t (*AAudioStream_getBufferCapacityInFrames )(AAudioStream* stream);
 int32_t (*AAudioStream_getFramesPerDataCallback)(AAudioStream* stream);
 int32_t (*AAudioStream_getXRunCount )(AAudioStream* stream);
 int32_t (*AAudioStream_getSampleRate )(AAudioStream* stream);
-int32_t (*AAudioStream_getSamplesPerFrame )(AAudioStream* stream);
+int32_t (*AAudioStream_getChannelCount )(AAudioStream* stream);
 int32_t (*AAudioStream_getDeviceId )(AAudioStream* stream);
 aaudio_format_t (*AAudioStream_getFormat )(AAudioStream* stream);
 aaudio_sharing_mode_t (*AAudioStream_getSharingMode )(AAudioStream* stream);
@@ -126,7 +126,7 @@ int32_t InitAAudio(void) {
   GET_PROC(AAudio_createStreamBuilder);
   GET_PROC(AAudioStreamBuilder_setDeviceId);
   GET_PROC(AAudioStreamBuilder_setSampleRate);
-  GET_PROC(AAudioStreamBuilder_setSamplesPerFrame);
+  GET_PROC(AAudioStreamBuilder_setChannelCount);
   GET_PROC(AAudioStreamBuilder_setFormat);
   GET_PROC(AAudioStreamBuilder_setSharingMode);
   GET_PROC(AAudioStreamBuilder_setDirection);
@@ -158,7 +158,7 @@ int32_t InitAAudio(void) {
 
   GET_PROC(AAudioStream_getXRunCount);
   GET_PROC(AAudioStream_getSampleRate);
-  GET_PROC(AAudioStream_getSamplesPerFrame);
+  GET_PROC(AAudioStream_getChannelCount);
   GET_PROC(AAudioStream_getDeviceId);
   GET_PROC(AAudioStream_getFormat);
   GET_PROC(AAudioStream_getSharingMode);
@@ -175,7 +175,7 @@ int32_t InitAAudio(void) {
       AAudio_createStreamBuilder &&
       AAudioStreamBuilder_setDeviceId &&
       AAudioStreamBuilder_setSampleRate &&
-      AAudioStreamBuilder_setSamplesPerFrame &&
+      AAudioStreamBuilder_setChannelCount &&
       AAudioStreamBuilder_setFormat &&
       AAudioStreamBuilder_setSharingMode &&
       AAudioStreamBuilder_setDirection &&
@@ -201,7 +201,7 @@ int32_t InitAAudio(void) {
       AAudioStream_getFramesPerDataCallback &&
       AAudioStream_getXRunCount &&
       AAudioStream_getSampleRate &&
-      AAudioStream_getSamplesPerFrame &&
+      AAudioStream_getChannelCount &&
       AAudioStream_getDeviceId &&
       AAudioStream_getFormat &&
       AAudioStream_getSharingMode &&


### PR DESCRIPTION
  AAudioStreamBuilder_setSamplesPerFrame() with AAudioStreamBuilder_setChannelCount()
  AAudioStream_getSamplesPerFrame() with AAudioStream_getChannelCount()

this is to address issue https://github.com/googlesamples/android-audio-high-performance/issues/68

@dturner @philburk PTAL