### PR TITLE
Adding comments covering order of closing streams

### DIFF
--- a/aaudio/echo/src/main/cpp/echo_audio_engine.h
+++ b/aaudio/echo/src/main/cpp/echo_audio_engine.h
@@ -51,16 +51,16 @@ private:
   std::mutex restartingLock_;
   AudioEffect audioEffect_;
 
-  void createRecordingStream();
+  void openRecordingStream();
   void drainRecordingStream(void *audioData, int32_t numFrames);
-  void createPlaybackStream();
+  void openPlaybackStream();
 
   void startStream(AAudioStream* stream);
   void stopStream(AAudioStream* stream);
   void closeStream(AAudioStream* stream);
 
-  void startStreams();
-  void stopStreams();
+  void openAllStreams();
+  void closeAllStreams();
   void restartStreams();
   AAudioStreamBuilder* createStreamBuilder();
 


### PR DESCRIPTION
- Renamed some methods to make it clearer when streams are being closed.
- Removed the calls to `stopStream` since `closeStream` does this implicitly. 
- Added comments to explain what's going on more clearly  