### PR TITLE
Oboe sample update: clone Oboe repo to Oboe/oboe directory

### DIFF
--- a/oboe/hello-oboe/CMakeLists.txt
+++ b/oboe/hello-oboe/CMakeLists.txt
@@ -19,7 +19,19 @@ cmake_minimum_required(VERSION 3.4.1)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror")
 
 # Include the Oboe library
-set (OBOE_DIR ../../../oboe)
+
+get_filename_component(OBOE_DIR
+                       ${CMAKE_CURRENT_SOURCE_DIR}/../lib-oboe
+                       ABSOLUTE)
+# clone Oboe repo if not cloned yet.
+if ((NOT EXISTS ${OBOE_DIR}) OR
+    (NOT EXISTS ${OBOE_DIR}/CMakeLists.txt))
+    execute_process(COMMAND git clone
+                            https://github.com/google/oboe.git
+                            ${OBOE_DIR}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
+endif()
+
 add_subdirectory(${OBOE_DIR} ./oboe)
 include_directories(${OBOE_DIR}/include ${OBOE_DIR}/src)
 

--- a/oboe/hello-oboe/CMakeLists.txt
+++ b/oboe/hello-oboe/CMakeLists.txt
@@ -18,12 +18,17 @@ cmake_minimum_required(VERSION 3.4.1)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror")
 
-# Include the Oboe library
+### INCLUDE OBOE LIBRARY ###
 
+# Set the path to the Oboe library directory (may not exist yet)
+set (OBOE_RELATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../lib-oboe)
+
+# Get the absolute path to the Oboe library directory
 get_filename_component(OBOE_DIR
-                       ${CMAKE_CURRENT_SOURCE_DIR}/../lib-oboe
+                       ${OBOE_RELATIVE_PATH}
                        ABSOLUTE)
-# clone Oboe repo if not cloned yet.
+
+# If the Oboe library directory doesn't exist, clone it from github
 if ((NOT EXISTS ${OBOE_DIR}) OR
     (NOT EXISTS ${OBOE_DIR}/CMakeLists.txt))
     execute_process(COMMAND git clone
@@ -32,8 +37,16 @@ if ((NOT EXISTS ${OBOE_DIR}) OR
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..)
 endif()
 
+# Add the Oboe library as a subproject. Since Oboe is an out-of-tree source library we must also
+# specify a binary directory
 add_subdirectory(${OBOE_DIR} ./oboe)
+
+# Include the Oboe headers
+# TODO: Remove 'src' from this list
+# see https://github.com/googlesamples/android-audio-high-performance/issues/95
 include_directories(${OBOE_DIR}/include ${OBOE_DIR}/src)
+
+### END OBOE INCLUDE SECTION ###
 
 # Debug utilities
 set (DEBUG_UTILS_PATH "../../debug-utils")


### PR DESCRIPTION
This is to address comment came from: https://github.com/googlesamples/android-audio-high-performance/issues/92.

- clone Oboe into Oboe's sample directory (making Oboe lib source code be part of the sample)

the directory is:
 android-audio-high-performance/oboe/lib-oboe
@dturner PTAL
