### PR TITLE
Add support for USB audio devices with more than 2 channels

### DIFF
--- a/oboe/hello-oboe/src/main/cpp/PlayAudioEngine.h
+++ b/oboe/hello-oboe/src/main/cpp/PlayAudioEngine.h
@@ -53,7 +53,7 @@ private:
     oboe::AudioApi mAudioApi = oboe::AudioApi::Unspecified;
     int32_t mPlaybackDeviceId = oboe::kUnspecified;
     int32_t mSampleRate;
-    int16_t mSampleChannels;
+    int32_t mSampleChannels;
     bool mIsToneOn = false;
     int32_t mFramesPerBurst;
     double mCurrentOutputLatencyMillis = 0;
@@ -64,8 +64,10 @@ private:
     std::mutex mRestartingLock;
 
     // The SineGenerators generate audio data, feel free to replace with your own audio generators
-    SineGenerator mSineOscLeft;
-    SineGenerator mSineOscRight;
+    SineGenerator mSineOscLeftOne;
+    SineGenerator mSineOscRightOne;
+    SineGenerator mSineOscLeftTwo;
+    SineGenerator mSineOscRightTwo;
 
     void createPlaybackStream();
 

--- a/oboe/hello-oboe/src/main/cpp/PlayAudioEngine.h
+++ b/oboe/hello-oboe/src/main/cpp/PlayAudioEngine.h
@@ -18,10 +18,12 @@
 #define OBOE_HELLOOBOE_PLAYAUDIOENGINE_H
 
 #include <thread>
+#include <array>
 #include <oboe/Oboe.h>
 #include "SineGenerator.h"
 
 constexpr int32_t kBufferSizeAutomatic = 0;
+constexpr int32_t kMaximumChannelCount = 8;
 
 class PlayAudioEngine : oboe::AudioStreamCallback {
 
@@ -48,12 +50,13 @@ public:
 
     void onErrorAfterClose(oboe::AudioStream *oboeStream, oboe::Result error);
 
+    void setChannelCount(int channelCount);
 
 private:
     oboe::AudioApi mAudioApi = oboe::AudioApi::Unspecified;
     int32_t mPlaybackDeviceId = oboe::kUnspecified;
     int32_t mSampleRate;
-    int32_t mSampleChannels;
+    int32_t mChannelCount;
     bool mIsToneOn = false;
     int32_t mFramesPerBurst;
     double mCurrentOutputLatencyMillis = 0;
@@ -64,10 +67,7 @@ private:
     std::mutex mRestartingLock;
 
     // The SineGenerators generate audio data, feel free to replace with your own audio generators
-    SineGenerator mSineOscLeftOne;
-    SineGenerator mSineOscRightOne;
-    SineGenerator mSineOscLeftTwo;
-    SineGenerator mSineOscRightTwo;
+    std::array<SineGenerator, kMaximumChannelCount> mOscillators;
 
     void createPlaybackStream();
 

--- a/oboe/hello-oboe/src/main/cpp/jni_bridge.cpp
+++ b/oboe/hello-oboe/src/main/cpp/jni_bridge.cpp
@@ -92,6 +92,21 @@ Java_com_google_sample_oboe_hellooboe_PlaybackEngine_native_1setAudioDeviceId(
 }
 
 JNIEXPORT void JNICALL
+Java_com_google_sample_oboe_hellooboe_PlaybackEngine_native_1setChannelCount(
+        JNIEnv *env,
+        jclass type,
+        jlong engineHandle,
+        jint channelCount) {
+
+    PlayAudioEngine *engine = (PlayAudioEngine *) engineHandle;
+    if (engine == nullptr) {
+        LOGE("Engine handle is invalid, call createHandle() to create a new one");
+        return;
+    }
+    engine->setChannelCount(channelCount);
+}
+
+JNIEXPORT void JNICALL
 Java_com_google_sample_oboe_hellooboe_PlaybackEngine_native_1setBufferSizeInBursts(
         JNIEnv *env,
         jclass,

--- a/oboe/hello-oboe/src/main/java/com/google/sample/oboe/hellooboe/PlaybackEngine.java
+++ b/oboe/hello-oboe/src/main/java/com/google/sample/oboe/hellooboe/PlaybackEngine.java
@@ -51,6 +51,10 @@ public class PlaybackEngine {
         if (mEngineHandle != 0) native_setAudioDeviceId(mEngineHandle, deviceId);
     }
 
+    static void setChannelCount(int channelCount) {
+        if (mEngineHandle != 0) native_setChannelCount(mEngineHandle, channelCount);
+    }
+
     static void setBufferSizeInBursts(int bufferSizeInBursts){
         if (mEngineHandle != 0) native_setBufferSizeInBursts(mEngineHandle, bufferSizeInBursts);
     }
@@ -70,6 +74,7 @@ public class PlaybackEngine {
     private static native void native_setToneOn(long engineHandle, boolean isToneOn);
     private static native void native_setAudioApi(long engineHandle, int audioApi);
     private static native void native_setAudioDeviceId(long engineHandle, int deviceId);
+    private static native void native_setChannelCount(long mEngineHandle, int channelCount);
     private static native void native_setBufferSizeInBursts(long engineHandle, int bufferSizeInBursts);
     private static native double native_getCurrentOutputLatencyMillis(long engineHandle);
     private static native boolean native_isLatencyDetectionSupported(long engineHandle);

--- a/oboe/hello-oboe/src/main/res/layout/activity_main.xml
+++ b/oboe/hello-oboe/src/main/res/layout/activity_main.xml
@@ -30,7 +30,8 @@
         android:layout_marginStart="@dimen/activity_horizontal_margin"
         android:layout_marginTop="@dimen/activity_vertical_margin"
         app:layout_constraintLeft_toLeftOf="parent"
-        android:id="@+id/audioApisTitleText"/>
+        android:id="@+id/audioApisTitleText"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin" />
     <Spinner
         android:id="@+id/audioApiSpinner"
         android:layout_width="wrap_content"
@@ -38,7 +39,7 @@
         android:layout_marginStart="@dimen/activity_horizontal_margin"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/audioApisTitleText"
-        />
+        android:layout_marginLeft="@dimen/activity_horizontal_margin" />
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -47,7 +48,9 @@
         android:layout_marginStart="@dimen/activity_horizontal_margin"
         android:layout_marginTop="@dimen/activity_vertical_margin"
         app:layout_constraintLeft_toLeftOf="parent"
-        android:id="@+id/playbackDeviceTitleText"/>
+        android:id="@+id/playbackDeviceTitleText"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin" />
+
     <com.google.sample.audio_device.AudioDeviceSpinner
         android:id="@+id/playbackDevicesSpinner"
         android:layout_width="wrap_content"
@@ -55,44 +58,71 @@
         android:layout_marginStart="@dimen/activity_horizontal_margin"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/playbackDeviceTitleText"
-        />
+        android:layout_marginLeft="@dimen/activity_horizontal_margin" />
+
+    <Spinner
+        android:id="@+id/channelCountSpinner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="8dp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/channelCountTitleText"
+        android:layout_marginStart="@dimen/activity_horizontal_margin" />
+
+    <TextView
+        android:id="@+id/channelCountTitleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="8dp"
+        android:text="Channel count"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/playbackDevicesSpinner"
+        android:layout_marginStart="@dimen/activity_horizontal_margin" />
+
     <TextView
         android:id="@+id/bufferSizeTitleText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="8dp"
         android:text="@string/buffer_size_title"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/playbackDevicesSpinner"
-        />
+        app:layout_constraintTop_toBottomOf="@+id/channelCountSpinner"
+        android:layout_marginStart="@dimen/activity_horizontal_margin" />
+
     <Spinner
         android:id="@+id/bufferSizeSpinner"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="4dp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/bufferSizeTitleText"
-        />
+        android:layout_marginStart="@dimen/activity_horizontal_margin" />
+
     <TextView
         android:id="@+id/latencyText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="12dp"
         android:text="@string/latency"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/bufferSizeSpinner"
-        />
-    <TextView android:text="@string/init_status"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:lines="3"
-              android:layout_marginStart="@dimen/activity_horizontal_margin"
-              android:layout_marginTop="@dimen/activity_vertical_margin"
-              android:id="@+id/userInstructionView"
-              app:layout_constraintLeft_toLeftOf="parent"
-              app:layout_constraintTop_toBottomOf="@+id/latencyText"
-              />
+        android:layout_marginStart="@dimen/activity_horizontal_margin" />
+
+    <TextView
+        android:id="@+id/userInstructionView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="20dp"
+        android:lines="3"
+        android:text="@string/init_status"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/latencyText"
+        android:layout_marginStart="@dimen/activity_horizontal_margin" />
 
 </android.support.constraint.ConstraintLayout>

--- a/oboe/hello-oboe/src/main/res/layout/channel_counts_spinner.xml
+++ b/oboe/hello-oboe/src/main/res/layout/channel_counts_spinner.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2018 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/channelCountOption"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/default_padding"
+    />


### PR DESCRIPTION
Added a drop down which allows the user to select the number of channels which they would like to use when creating the audio stream. This is useful when testing USB audio devices which have more than 2 channels. The maximum number of channels is 8. 