### PR TITLE
Update build to Android Studio 3.1.4

### DIFF
--- a/SimpleSynth/app/build.gradle
+++ b/SimpleSynth/app/build.gradle
@@ -2,12 +2,11 @@ apply plugin: 'com.android.application'
 
 
 android{
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 25
+        targetSdkVersion 26
         applicationId "com.example.simplesynth"
         versionName "3.0"
         versionCode 3
@@ -44,5 +43,5 @@ android{
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:28.0.0-rc02'
 }

--- a/SimpleSynth/build.gradle
+++ b/SimpleSynth/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -13,6 +14,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/SimpleSynth/gradle/wrapper/gradle-wrapper.properties
+++ b/SimpleSynth/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/aaudio/build.gradle
+++ b/aaudio/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/aaudio/gradle/wrapper/gradle-wrapper.properties
+++ b/aaudio/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 16 16:25:02 BST 2017
+#Wed Sep 05 13:31:35 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Fix https://github.com/googlesamples/android-audio-high-performance/issues/119 : update to build to gradle plugin version 3.1.4

@philburk PTAL, thanks